### PR TITLE
fixes error preventing adding multiple members

### DIFF
--- a/meteor-app/imports/ui/member/member-add-avatar-widget.js
+++ b/meteor-app/imports/ui/member/member-add-avatar-widget.js
@@ -25,9 +25,7 @@ const AvatarWidget = (props) => {
               <Image
                 circular
                 style={{
-                  // flex: '0 1 20%',
                   height: "80px",
-                  // width: "80px",
                   margin: '5px',
                   boxShadow: '0px 2px 2px 1px rgba(0,0,0,.25)',
                   border: (props.value == option.value) ? '5px solid #00ff8d' : 'none',
@@ -43,6 +41,7 @@ const AvatarWidget = (props) => {
         }
       </div>
       <input
+        hidden
         type='text'
         value={props.value}
         required={props.required}

--- a/meteor-app/imports/ui/member/member-add-avatar-widget.js
+++ b/meteor-app/imports/ui/member/member-add-avatar-widget.js
@@ -43,7 +43,6 @@ const AvatarWidget = (props) => {
         }
       </div>
       <input
-        hidden
         type='text'
         value={props.value}
         required={props.required}

--- a/meteor-app/imports/ui/member/member-add-container.js
+++ b/meteor-app/imports/ui/member/member-add-container.js
@@ -9,11 +9,11 @@ const error = new ReactiveVar(false)
 const msg = new ReactiveVar('')
 const newId = new ReactiveVar('')
 
-
-export default withTracker((props) => {
+export default withTracker(() => {
   const addMember = (formData) => {
     return Meteor.call('members.insert', formData, (err, res) => {
       if (err) {
+        newId.set('')
         error.set(true)
         success.set(false)
         msg.set(err.reason)
@@ -34,5 +34,6 @@ export default withTracker((props) => {
     message: msg.get(),
     isIframe: isIframe(),
     newId: newId.get(),
+    resetId: () => newId.set(''),
   }
 })(MemberAdd)

--- a/meteor-app/imports/ui/member/member-add.js
+++ b/meteor-app/imports/ui/member/member-add.js
@@ -47,8 +47,12 @@ class MemberAdd extends Component {
     }
   }
 
-  onSubmit = ({ formData }) => {
+  componentWillUnmount() {
+    // prevents id from persisting between adding users
+    this.props.resetId()
+  }
 
+  onSubmit = ({ formData }) => {
     const finalStep = schemas.length == this.state.step
     if (finalStep) {
       this.props.addMember(this.state.formData)
@@ -84,7 +88,6 @@ class MemberAdd extends Component {
       schema={schemas[this.state.step].schema}
       uiSchema={schemas[this.state.step].uiSchema}
       formData={this.state.formData}
-      onChange={this.onChange}
       onSubmit={this.onSubmit}
       widgets={widgets}
       fields={fields}
@@ -142,6 +145,7 @@ class MemberAdd extends Component {
 
 MemberAdd.propTypes = {
   addMember: PropTypes.func.isRequired,
+  resetId: PropTypes.func.isRequired,
   error: PropTypes.bool.isRequired,
   success: PropTypes.bool.isRequired,
   message: PropTypes.string.isRequired,


### PR DESCRIPTION
fixes issue where new userId from preceding `member.insert` call was hanging around, causing issues in UI and preventing subsequent members from being inserted.
Want to make the whole success/error/message structure more solid in the member-add-container, but its working well now as is.


Add any links to relevant Trello/Invision urls.

### Done Checklist
* [ ] Feature implemented or bug resolved as per the Trello card
* [ ] All acceptance criteria are met
* [ ] Tests have been added or updated
* [ ] Views are responsive for mobile devices
* [ ] Feature files have been written or updated
* [ ] Changelog updated where appropriate
