### PR TITLE
Change navbar display setting from stackable to unstackable

### DIFF
--- a/meteor-app/imports/ui/member/member-nav.js
+++ b/meteor-app/imports/ui/member/member-nav.js
@@ -7,7 +7,7 @@ import Search from '/imports/ui/member/member-search-container'
 const Nav = (props) => {
 
   return (
-    <Menu fixed='top' stackable>
+    <Menu fixed='top' unstackable fluid>
       <Menu.Item onClick={() => { props.history.push('/') }}>
         <Image src='/images/logo-tiny.jpg' />
       </Menu.Item>


### PR DESCRIPTION
Hi Mike,

This is a very minor change we would like to make to your existing navbar - changing it from 'stackable' to 'unstackable'. Currently if we test the app on a smaller screen (iphone, ipad) the navbar stacks down and covers the content on the page.
Thanks!

### Done Checklist

* [ ] Task has been completed as per the Trello card
* [ ] All acceptance criteria are met
* [ ] Developer has tested this locally
* [ ] Developer has reviewed their own PR
* [ ] Design has been reviewed by design team
* [ ] Tests have been added or updated
* [ ] Views are responsive for mobile devices
* [ ] Feature files have been written or updated
* [ ] Changelog updated
