### PR TITLE
move checkboxes to customer details step

### DIFF
--- a/meteor-app/imports/ui/assessment/assessment-add.js
+++ b/meteor-app/imports/ui/assessment/assessment-add.js
@@ -314,7 +314,7 @@ class AssessmentAdd extends Component {
     const date = new Date()
     const dateOneWeekLater = new Date(date.setDate(date.getDate() + 7))
     const formattedDate = moment(dateOneWeekLater).format('YYYY-MM-DD')
-    schemas[2].schema.properties.pickUpDate.default = formattedDate
+    schemas[4].schema.properties.pickUpDate.default = formattedDate
     const data = this.state.costData
     const showPrice = this.state.step === 1 || this.state.step === 2
 

--- a/meteor-app/imports/ui/config/bike-assessment-schemas.js
+++ b/meteor-app/imports/ui/config/bike-assessment-schemas.js
@@ -99,7 +99,6 @@ export default [{
     schema: {
       type: "object",
       title: "Select Parts",
-      required: ['pickUpDate'],
       properties: {
         parts: {
           type: "array",
@@ -122,24 +121,7 @@ export default [{
           type: "integer",
           title: "Enter additional fee if required (list reason in comments)"
         },
-        replacementBike: {
-          type: "boolean",
-          title: "Replacement bike required?"
-        },
-        sentimentalValue: {
-          type: "boolean",
-          title: "Does bike have sentimental value?"
-        },
-        requestUrgent: {
-          type: "boolean",
-          title: "Is this request urgent?"
-        },
-        pickUpDate: {
-          type: "string",
-          title: "Pick-up Date",
-          format: "date",
-          default: "2018-10-10"
-        },
+        
       },
     },
     uiSchema: {
@@ -161,13 +143,10 @@ export default [{
         "ui:placeholder": "$Additional Fee",
         "ui:widget": "updown"
       },
-      replacementBike: {},
-      sentimentalValue: {},
-      requestUrgent: {
 
-      },
     }
   },
+
   {
     stepTitle: 'Review',
     stepDescription: '',
@@ -190,6 +169,12 @@ export default [{
           title: "Is this bike being refurbished by Back 2 Bikes?",
           default: false
         },
+        pickUpDate: {
+          type: "string",
+          title: "Pick-up Date",
+          format: "date",
+          default: "2018-10-10"
+        },
       },
       dependencies: {
         b2bRefurbish: {
@@ -197,8 +182,8 @@ export default [{
             {
               properties: {
                 b2bRefurbish: { enum: [true, ""] }
-              }
-            },
+              },
+          },
             {
               properties: {
                 b2bRefurbish: { enum: [false] },
@@ -214,6 +199,22 @@ export default [{
                   type: "string",
                   title: "Email"
                 },
+                replacementBike: {
+                  type: "boolean",
+                  title: "Replacement bike required?",
+                  default: false
+                },
+                sentimentalValue: {
+                  type: "boolean",
+                  title: "Does bike have sentimental value?",
+                  default: false
+                },
+                requestUrgent: {
+                  type: "boolean",
+                  title: "Is this request urgent?",
+                  default: false
+                },
+        
               },
               required: ["name", "phone", "email"]
             }
@@ -227,7 +228,10 @@ export default [{
       phone: {},
       email: {
         "ui:widget": "email"
-      }
+      },
+      replacementBike: {},
+      sentimentalValue: {},
+      requestUrgent: {},
     },
   }
 ]

--- a/meteor-app/package-lock.json
+++ b/meteor-app/package-lock.json
@@ -12808,11 +12808,11 @@
           "from": "git+https://github.com/meteor/readable-stream.git",
           "dev": true,
           "requires": {
-            "inherits": "~2.0.1",
+            "inherits": "~2.0.3",
             "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "safe-buffer": "^5.0.1",
-            "string_decoder": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.0",
             "util-deprecate": "~1.0.1"
           }
         },


### PR DESCRIPTION
Hi Mike!
This pull request is just to move replacement bike checkbox, sentimental value checkbox, urgent request checkbox and pick up date from the parts step to the customer details step.
Please review,
Erin 

### Done Checklist

* [ ] Task has been completed as per the Trello card
* [ ] All acceptance criteria are met
* [ ] Developer has tested this locally
* [ ] Developer has reviewed their own PR
* [ ] Design has been reviewed by design team
* [ ] Tests have been added or updated
* [ ] Views are responsive for mobile devices
* [ ] Feature files have been written or updated
* [ ] Changelog updated
