### PR TITLE
Sticky folds

### DIFF
--- a/b2b-app/imports/ui/admin/forms/framework/editor-panel.js
+++ b/b2b-app/imports/ui/admin/forms/framework/editor-panel.js
@@ -118,6 +118,10 @@ export const EditorPanel = ({ editor }) => {
     ],
   })
 
+  React.useEffect(() => {
+    reapplyFolds(codemirrorRef.current.editor)
+  }, [editor.name])
+
   // Set height of codemirror
   React.useEffect(() => {
     if (editor.editorType === 'form') {
@@ -161,15 +165,20 @@ export const EditorPanel = ({ editor }) => {
     return () => window.removeEventListener('resize', () => setSplitSize('85%'))
   })
 
-  React.useEffect(() => {
-    const lines = codemirrorRef.current.editor.lastLine()
+  const reapplyFolds = (e) => {
+    const lines = e.lastLine()
 
-    for (let i = 0; i <= lines; i++) {
+    for (let i = lines - 1; i >= 0; i--) {
       if (formContext.folds[editor.name][i]) {
-        codemirrorRef.current.editor.foldCode(CM.Pos(i))
+        if (
+          (e.isFolded(CM.Pos(i)) ? true : false) !== formContext.folds[editor.name][i]
+        ) {
+          e.foldCode(CM.Pos(i))
+        }
       }
     }
-  }, [editor.name])
+    console.log('applied')
+  }
 
   const debounce = (callback, wait = 3000) => {
     return (...args) => {
@@ -219,6 +228,7 @@ export const EditorPanel = ({ editor }) => {
             formContext.setEditorDoc(editor)
             CM.commands.save = () => formContext.save(false)
           }}
+          editorDidConfigure={reapplyFolds}
         />
       </div>
     )

--- a/b2b-app/imports/ui/admin/forms/framework/editor-panel.js
+++ b/b2b-app/imports/ui/admin/forms/framework/editor-panel.js
@@ -161,6 +161,16 @@ export const EditorPanel = ({ editor }) => {
     return () => window.removeEventListener('resize', () => setSplitSize('85%'))
   })
 
+  React.useEffect(() => {
+    const lines = codemirrorRef.current.editor.lastLine()
+
+    for (let i = 0; i <= lines; i++) {
+      if (formContext.folds[editor.name][i]) {
+        codemirrorRef.current.editor.foldCode(CM.Pos(i))
+      }
+    }
+  }, [editor.name])
+
   const debounce = (callback, wait = 3000) => {
     return (...args) => {
       window.clearTimeout(timeoutId)
@@ -194,6 +204,14 @@ export const EditorPanel = ({ editor }) => {
           }}
           onBeforeChange={(e, data, value) => {
             editor.updateEditor(value)
+          }}
+          onGutterClick={(e, line, gutter, ev) => {
+            console.log(line, 'folded', e.isFolded(CM.Pos(line)))
+            formContext.updateFold(
+              line,
+              e.isFolded(CM.Pos(line)) ? true : false,
+              editor.name
+            )
           }}
           onChange={handleEditorInput}
           ref={codemirrorRef}

--- a/b2b-app/imports/ui/admin/forms/framework/framework.js
+++ b/b2b-app/imports/ui/admin/forms/framework/framework.js
@@ -84,6 +84,28 @@ const Framework = ({ id, item, methods }) => {
       : 'single'
   )
 
+  const [folds, setFolds] = React.useState(
+    localStorage.getItem('folds') ? JSON.parse(localStorage.getItem('folds')) : {}
+  )
+  const currentFolds = { form: {}, json: {} }
+
+  const updateFold = (line, isFold, editorType) => {
+    currentFolds[editorType][line] = isFold
+    // console.log('updated fold', currentFolds)
+    saveFolds()
+  }
+
+  const saveFolds = () => {
+    // console.log('saved folds', currentFolds)
+    const updated = {
+      json: { ...folds.json, ...currentFolds.json },
+      form: { ...folds.form, ...currentFolds.form },
+    }
+    // console.log(updated)
+    setFolds(updated)
+    localStorage.setItem('folds', JSON.stringify(updated))
+  }
+
   const changeLayout = (newLayout) => {
     const layouts = ['single', 'double', 'dnd']
 
@@ -191,13 +213,13 @@ const Framework = ({ id, item, methods }) => {
         value={{
           editors: [
             {
-              name: 'details.form',
+              name: 'form',
               editorValue: formEditorInput,
               updateEditor: updateFormInput,
               editorType: 'form',
             },
             {
-              name: 'detailsForm.json',
+              name: 'json',
               editorValue: jsonEditorInput,
               updateEditor: updateJsonInput,
               editorType: { name: 'javascript', json: true },
@@ -224,6 +246,8 @@ const Framework = ({ id, item, methods }) => {
           changeLayout,
           name: item.name,
           slug: item.slug,
+          folds,
+          updateFold,
         }}
       >
         <EditorToolbar />


### PR DESCRIPTION
Folded sections of code are now retained after refresh, tab change and layout change (this should be all instances where the editor is "reconfigured" and folds would ordinarilty reset).

{ Link to the Trello card }
{ Link to applicable Invision designs }


### Done Checklist

* [ ] Task has been completed as per the Trello card
* [ ] All acceptance criteria are met
* [ ] Developer has tested this locally
* [ ] Developer has reviewed their own PR
* [ ] Design has been reviewed by design team
* [ ] Tests have been added or updated
* [ ] Views are responsive for mobile devices
* [ ] Feature files have been written or updated
* [ ] Changelog updated
