### PR TITLE
Fix bug where text editor crashes on load

### DIFF
--- a/b2b-app/imports/ui/admin/forms/framework/framework.js
+++ b/b2b-app/imports/ui/admin/forms/framework/framework.js
@@ -84,10 +84,10 @@ const Framework = ({ id, item, methods }) => {
       : 'single'
   )
 
-  const [folds, setFolds] = React.useState(
-    localStorage.getItem('folds') ? JSON.parse(localStorage.getItem('folds')) : {}
-  )
   const currentFolds = { form: {}, json: {} }
+  const [folds, setFolds] = React.useState(
+    localStorage.getItem('folds') ? JSON.parse(localStorage.getItem('folds')) : currentFolds
+  )
 
   const updateFold = (line, isFold, editorType) => {
     currentFolds[editorType][line] = isFold


### PR DESCRIPTION
Fixes bug introduced by https://github.com/Back2bikes/attendance/pull/223

### Bug: 

1. Delete the `folds` key from local storage, if one exists.
2. In `/admin/forms`, add a new form with the default source code 
3. Click the pencil icon to start the text editor
4. App crashes and logs something like "can't access property [3] of undefined' referencing line 172 in `reapplyFolds` function in `editor-panel.js`

### Cause:

On Line 172 `if (formContext.folds[editor.name][i])`, the `folds` value is initialised to an empty object in `framework.js`. When the `reapplyFolds` function tries to access `folds['form']`, it evaluates to undefined and then tries to do array indexing on it which causes the crash

### Fix:

When `folds` is missing from local storage, Initialise the `folds` context value with an object with the editor names so that line 172 can always access an index.

### Done Checklist

* [ ] Task has been completed as per the Trello card
* [ ] All acceptance criteria are met
* [x] Developer has tested this locally
* [x] Developer has reviewed their own PR
* [ ] Design has been reviewed by design team
* [ ] Tests have been added or updated
* [ ] Views are responsive for mobile devices
* [ ] Feature files have been written or updated
* [ ] Changelog updated
